### PR TITLE
Add support for deep-url configuration starting from the current pathname going up

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -8,9 +8,9 @@ const getConfig = (filename = 'storybook-config.json') => (
     } else if (window && window.parent) {
       lastFilename = filename;
       const url = window.parent.location;
-      const location = `${url.protocol}//${url.hostname}:${url.port}/${filename}`;
+      const origin = `${url.protocol}//${url.hostname}:${url.port}`;
 
-      fetch(location).then((response) => {
+      const fetchConfig = pathParts => fetch(`${origin}/${pathParts.join('/')}${filename}`).then((response) => {
         if (response.ok) {
           response.json().then((data) => {
             if (data && data.storybook && data.storybook.versions) {
@@ -24,7 +24,15 @@ const getConfig = (filename = 'storybook-config.json') => (
           reject('Response not ok');
         }
       }).catch(() => {
-        reject('Error getting config');
+        if (pathParts.filter(_ => _).length === 0) {
+          throw new Error('Error getting config');
+        }
+
+        return fetchConfig(pathParts.slice(0, pathParts.length - 2).concat(['']));
+      });
+
+      fetchConfig(url.pathname.split('/').filter(_ => _).concat([''])).catch((e) => {
+        reject(e.message);
       });
     } else {
       reject('Window not found');


### PR DESCRIPTION
Fixes #10 

Instead of assuming the configuration file exists in a specific location on the server, this now traverses from the current directory to up the origin to find the configuration file.
By doing this we allow to deploy this to github pages.

Couldn't figure out how to test this locally.
`npm start` started storybook but the other versions weren't available.
Would be happy to see this work in action though 😃 