### PR TITLE
Fetch root config when version doesn't have one

### DIFF
--- a/src/utils/__tests__/config.js
+++ b/src/utils/__tests__/config.js
@@ -61,6 +61,20 @@ describe('Config', () => {
             json: () => new Promise(res => res(invalid)),
           });
         });
+      } else if (location.search('blank/version_response_not_ok_but_root_is.json') !== -1) {
+        p = new Promise((resolve) => {
+          resolve({
+            ok: false,
+            json: () => new Promise(res => res(invalid)),
+          });
+        });
+      } else if (location.search('version_response_not_ok_but_root_is.json') !== -1) {
+        p = new Promise((resolve) => {
+          resolve({
+            ok: true,
+            json: () => new Promise(res => res(file1)),
+          });
+        });
       } else {
         p = new Promise((resolve, reject) => reject());
       }
@@ -69,6 +83,10 @@ describe('Config', () => {
   });
   afterAll(() => {
     global.fetch.mockRestore();
+  });
+
+  afterEach(() => {
+    global.fetch.mockClear();
   });
 
   it('Get the default config if no filename supplied', async () => {
@@ -88,7 +106,18 @@ describe('Config', () => {
 
   it('Throws an error when the response is not ok', async () => {
     expect.assertions(1);
-    await expect(getConfig('response_not_ok.json')).rejects.toEqual('Response not ok');
+    await expect(getConfig('response_not_ok.json')).rejects.toEqual('Error getting config');
+  });
+
+  it('Get the root config when a filename does not exist in one of the versions', async () => {
+    expect.assertions(4);
+    await expect(getConfig('version_response_not_ok_but_root_is.json')).resolves.toEqual(file1.storybook.versions);
+
+    const mockCalls = global.fetch.mock.calls;
+
+    expect(mockCalls).toHaveLength(2);
+    expect(mockCalls[0][0]).toEqual('about://:/blank/version_response_not_ok_but_root_is.json');
+    expect(mockCalls[1][0]).toEqual('about://:/version_response_not_ok_but_root_is.json');
   });
 
   it('Throw an error when an invalid file is requested', async () => {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -21,7 +21,7 @@ const getConfig = (filename = 'storybook-config.json') => (
             }
           });
         } else {
-          reject('Response not ok');
+          throw new Error('Response not ok');
         }
       }).catch(() => {
         if (pathParts.filter(_ => _).length === 0) {


### PR DESCRIPTION
If I have a directory structure like this 
```bash
.
├── static
│   ├── manager.c2ca3b28e7a25aae27ab.bundle.js
│   └── preview.c03632fa3b30af3d9784.bundle.js
├── v1
│   ├── static
│   ├── favicon.ico
│   ├── iframe.html
│   └── index.html
├── v2
│   ├── static
│   ├── favicon.ico
│   ├── iframe.html
│   └── index.html
├── v3
│   ├── static
│   ├── favicon.ico
│   ├── iframe.html
│   └── index.html
├── favicon.ico
├── iframe.html
├── index.html
└── storybook-config.json
```
You should safely assume that there will be one `storybook-config.json` file stored in the root directory where you see all available-versions and other configs. IMHO this file shouldn't be redundant in every version.

The issue is, with the current implementation, in each version, the addon tries to load the `storybook-config.json` in that version, and if it is not there, it will reject the promise, that's based on `fetch` [specifications](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch), it will always return a promise that resolves to a `Response` object (ok will be false in case of 404), but we should instead load the config file from the root directory, and that's basically what I did.
